### PR TITLE
Fix: Use User Timezone Instead of UTC

### DIFF
--- a/backend/app/api/routers/chat.py
+++ b/backend/app/api/routers/chat.py
@@ -437,7 +437,7 @@ async def chat(
 
             rag_engine = None
             try:
-                rag_engine = get_chat_engine(filters=filters, params=params)
+                rag_engine = get_chat_engine(filters=filters, params=params, timezone=user_timezone)
                 followup_prompt = (
                     "A calendar card is already displayed showing relevant dates and deadlines. "
                     "Now provide a helpful text answer to the user's question in 2-4 concise sentences. "
@@ -577,7 +577,7 @@ async def chat(
             logger.info(
                 f"Creating chat engine with filters: {str(filters)}",
             )
-            chat_engine = get_chat_engine(filters=filters, params=params)
+            chat_engine = get_chat_engine(filters=filters, params=params, timezone=user_timezone)
             chat_engine.callback_manager.handlers.append(event_handler)  # type: ignore
 
             response = await chat_engine.astream_chat(last_message_content, messages)
@@ -602,7 +602,7 @@ async def chat(
 
         async def _rag_fallback_for_calendar():
             """If calendar pipeline times out, answer via normal RAG."""
-            engine = get_chat_engine(filters=filters, params=params)
+            engine = get_chat_engine(filters=filters, params=params, timezone=user_timezone)
             engine.callback_manager.handlers.append(event_handler)
             return await engine.astream_chat(last_message_content, messages)
 
@@ -735,10 +735,11 @@ async def chat_request(
         params = data.data or {}
         role = params.get("role", "missionary")
         filters = generate_filters(doc_ids, role)
+        user_timezone = request.headers.get("X-Timezone", "UTC")
         logger.info(
             f"Creating chat engine with filters: {str(filters)}",
         )
-        chat_engine = get_chat_engine(filters=filters, params=params)
+        chat_engine = get_chat_engine(filters=filters, params=params, timezone=user_timezone)
 
         response = await chat_engine.achat(last_message_content, messages)
 

--- a/backend/app/engine/__init__.py
+++ b/backend/app/engine/__init__.py
@@ -78,17 +78,25 @@ def get_chat_engine(filters=None, params=None, timezone: str = "UTC") -> CustomC
         filters=filters,
     )
     
-    # Use user's timezone to determine current date
+    # Use user's timezone to determine current date and time
     try:
         now = datetime.now(ZoneInfo(timezone))
+        tz_name = timezone
     except Exception:
         # Fallback to UTC if the provided timezone is invalid
         now = datetime.now(ZoneInfo("UTC"))
+        tz_name = "UTC"
+    
+    # Format: "March 23, 2026 at 9:17 AM MDT"
     current_date = now.strftime("%B %d, %Y")
+    current_time = now.strftime("%I:%M %p").lstrip('0')  # Remove leading zero from hour
+    tz_abbr = now.strftime("%Z")  # Timezone abbreviation (e.g., MDT, PST, UTC)
+    current_datetime = f"{current_date} at {current_time} {tz_abbr}"
+    
     temporal_status = _precomputed_temporal_status(now)
 
     SYSTEM_CITATION_PROMPT = f"""
-    IMPORTANT - Today's date is {current_date}. Use this information when answering questions about dates, deadlines, terms, blocks, semesters, and the academic calendar. If the user asks what today's date is, tell them directly.
+    IMPORTANT - Today's date and time is {current_datetime}. Use this information when answering questions about dates, times, deadlines, terms, blocks, semesters, and the academic calendar. If the user asks what today's date is or what time it is, tell them directly.
 
     {temporal_status}
 

--- a/backend/app/engine/__init__.py
+++ b/backend/app/engine/__init__.py
@@ -53,7 +53,7 @@ def _precomputed_temporal_status(now: datetime) -> str:
     return "\n".join(lines)
 
 
-def get_chat_engine(filters=None, params=None) -> CustomCondensePlusContextChatEngine:
+def get_chat_engine(filters=None, params=None, timezone: str = "UTC") -> CustomCondensePlusContextChatEngine:
     node_postprocessors = []
     
     node_postprocessors = [NodeCitationProcessor()]
@@ -78,7 +78,12 @@ def get_chat_engine(filters=None, params=None) -> CustomCondensePlusContextChatE
         filters=filters,
     )
     
-    now = datetime.now(ZoneInfo("UTC"))
+    # Use user's timezone to determine current date
+    try:
+        now = datetime.now(ZoneInfo(timezone))
+    except Exception:
+        # Fallback to UTC if the provided timezone is invalid
+        now = datetime.now(ZoneInfo("UTC"))
     current_date = now.strftime("%B %d, %Y")
     temporal_status = _precomputed_temporal_status(now)
 


### PR DESCRIPTION
The Missionary Assistant showed an incorrect date because it used a fixed timezone instead of the user’s local timezone.

## Root Cause
`get_chat_engine()` in `backend/app/engine/__init__.py` was hardcoded to `datetime.now(ZoneInfo("UTC"))` even though the frontend sends the user's timezone via the `X-Timezone` header.

## Solution
1. Modified `get_chat_engine()` to accept a `timezone` parameter (defaults to "UTC")
2. Added error handling to fallback to UTC if timezone is invalid
3. Enhanced to include both date AND time: `"March 20, 2026 at 9:37 AM MDT"`
4. Updated all 4 call sites in `chat.py` to pass `user_timezone`

Now the assistant can answer both "what day is today" and "what time is it" correctly for each user's timezone.
