### PR TITLE
fix: Cap Response Length and Improve Refusal Messages

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,8 +22,8 @@ OPENAI_API_KEY=your_openai_api_key
 # Temperature for sampling from the model.
 # LLM_TEMPERATURE=0
 
-# Maximum number of tokens to generate.
-# LLM_MAX_TOKENS=
+# Maximum number of tokens to generate (caps response length to prevent runaway output).
+LLM_MAX_TOKENS=1024
 
 # The number of similar embeddings to return when retrieving documents.
 TOP_K=3

--- a/backend/app/engine/__init__.py
+++ b/backend/app/engine/__init__.py
@@ -134,10 +134,17 @@ def get_chat_engine(filters=None, params=None, timezone: str = "UTC") -> CustomC
     Ensure that each referenced piece of information is correctly cited.
 
     ABSOLUTE RULE — NO EXCEPTIONS:
-    If the information required to answer the question is not available in the retrieved nodes, respond ONLY with a short refusal. Do NOT use your general knowledge, do NOT generate content (poems, stories, code, recipes, math, etc.), do NOT answer questions about other universities, weather, or any topic not covered by the retrieved nodes.
-    - For questions outside BYU-Pathway: "I only have information about BYU-Pathway Worldwide. For help, check [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact)."
-    - For BYU-Pathway questions where the answer isn't in the nodes: "I'm not sure about that, but you can check [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact) for help."
-    - NEVER elaborate, speculate, or generate content beyond what the sources provide. If the nodes don't have it, say so and stop.
+    If the information required to answer the question is not available in the retrieved nodes, respond ONLY with a short refusal (1-2 sentences max). Do NOT use your general knowledge, do NOT generate content (poems, stories, code, recipes, scripture lists, math, etc.), do NOT answer questions about other universities, weather, or any topic not covered by the retrieved nodes.
+
+    Choose ONE of the following short refusals depending on context. Vary your response — do NOT repeat the same refusal every time:
+    - "I don't have details on that, but someone in [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact) should be able to help."
+    - "That's outside what I know at the moment. [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact) might point in the right direction."
+    - "I couldn't find that information. Check [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact) for more help."
+    - "I don't have an answer for that right now."
+    - "I only have information about BYU-Pathway Worldwide. For help, check [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact)."
+    - If the user pushes back: "I wish I could help with that, but I don't have enough info right now. Try reaching out to someone listed in [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact)."
+
+    CRITICAL: After giving a refusal, STOP. Do NOT elaborate, speculate, list scriptures, generate content, or add anything beyond the short refusal. One or two sentences, then stop.
 
     Definitions to keep in mind:
     - Friend of the Church: An individual who is not a member of The Church of Jesus Christ of Latter-day Saints.
@@ -213,13 +220,13 @@ def get_chat_engine(filters=None, params=None, timezone: str = "UTC") -> CustomC
 
     Answer the question as truthfully as possible using the numbered contexts below. For each sentence in the answer, include a citation using the format [^context number].
 
-    STRICT RULE: ONLY use facts from the numbered contexts below. If the answer is not in the contexts, respond with a short refusal and link to Who to Contact. Do NOT use general knowledge. Do NOT generate poems, stories, code, math, recipes, or any content not in the contexts. Do NOT answer questions about other universities or unrelated topics.
+    STRICT RULE: ONLY use facts from the numbered contexts below. If the answer is not in the contexts, give a short 1-2 sentence refusal (vary wording) and link to [Who to Contact](https://missionaries.prod.byu-pathway.psdops.com/who-to-contact), then STOP. Do NOT use general knowledge. Do NOT generate poems, stories, scripture lists, code, math, recipes, or any content not in the contexts. Do NOT answer questions about other universities or unrelated topics.
 
     Contexts:
     {context_str}
 
     Instruction: Based on the above documents, provide a clear answer for the user question below. Cite each statement, e.g., 'This is the answer [^1]. This is part of the answer [^2]...'
-    If the contexts do not contain the answer, say so briefly and stop. Do not elaborate beyond what the sources provide.
+    If the contexts do not contain the answer, give a short refusal (1-2 sentences max) and stop immediately. Do not elaborate, list items, or generate content beyond what the sources provide.
     Wording rule: avoid second-person pronouns such as "you" and "your". Prefer "students", "the student", "missionaries", or neutral phrasing.
     """
     


### PR DESCRIPTION
- Set `LLM_MAX_TOKENS=1024` to prevent runaway responses (e.g., 10-minute scripture dumps that cost money and lock the session). 

- Replace rigid two-template refusal system with a pool of short, conversational refusals that the LLM varies contextually. Add explicit "scripture lists" to the banned content types and reinforce STOP after refusal.